### PR TITLE
Fix: Add missing aria-labels to footer social media icons

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -237,10 +237,11 @@
       <div>
         <h3>PlacementorAI</h3>
         <p>Your intelligent companion for career growth and recruitment management. Streamlining the path from campus to corporate.</p>
+        <!-- Fix: Added aria-label to footer social icons for screen reader accessibility -->
         <div class="footer-social">
-          <a href="#"><i class="fa-brands fa-linkedin"></i></a>
-          <a href="#"><i class="fa-brands fa-github"></i></a>
-          <a href="#"><i class="fa-brands fa-x-twitter"></i></a>
+          <a href="#" aria-label="LinkedIn"><i class="fa-brands fa-linkedin"></i></a>
+          <a href="#" aria-label="GitHub"><i class="fa-brands fa-github"></i></a>
+          <a href="#" aria-label="Twitter"><i class="fa-brands fa-x-twitter"></i></a>
         </div>
       </div>
       <div>


### PR DESCRIPTION
## Description
Added missing aria-label attributes to the footer social media 
icon links in frontend/index.html.

The LinkedIn, GitHub, and Twitter icon links had no text content 
and no aria-label, making them completely inaccessible to screen 
readers. Users relying on assistive technology had no way to 
identify what these links were.

## Type of Change
- [x] Bug fix

## Changes Made
| File | Change |
|------|--------|
| `frontend/index.html` | Added aria-label="LinkedIn", aria-label="GitHub", and aria-label="Twitter" to footer social icon links |

## How to Test
1. Open frontend/index.html in browser
2. Inspect the footer social icons
3. Verify aria-label attributes are present on all three links

## Checklist
- [x] I have performed a self-review of my code
- [x] My changes do not break any existing functionality
- [x] I have commented my code in hard-to-understand areas
- [x] I have tested changes locally