### PR TITLE
fix(frontend): resolve token mismatch in centralized apiRequest

### DIFF
--- a/frontend/utils/api.js
+++ b/frontend/utils/api.js
@@ -1,7 +1,11 @@
 const API_BASE = "http://localhost:5000/api";
 
 export async function apiRequest(endpoint, method = "GET", body) {
-  const token = localStorage.getItem("token");
+  // 1. Safely parse the nested token from the main session object
+  const session = JSON.parse(localStorage.getItem("placementor_session"));
+  
+  // 2. Fallback to standalone token string to prevent breaking any other views
+  const token = session?.token || localStorage.getItem("token");
 
   const res = await fetch(API_BASE + endpoint, {
     method,


### PR DESCRIPTION
## 🔗 Related Issues
Closes  #161


## 🛠️ Description 
This Pull Request resolves a critical token retrieval defect in the centralized API utility handler. 

Previously, `frontend/utils/api.js` looked for a standalone string key (`localStorage.getItem("token")`). However, the login system saves the user session as a nested object under the key `"placementor_session"`. This caused the utility to build an invalid header (`Authorization: Bearer null`), resulting in uniform `401 Unauthorized` responses from the backend.

## ✨ Changes Made
* Refactored `frontend/utils/api.js` to safely parse the `"placementor_session"` object from local storage.
* Implemented optional chaining (`session?.token`) to cleanly extract the active token.
* Retained a backward-compatible fallback (`|| localStorage.getItem("token")`) to ensure zero disruption to any legacy standalone token implementations across other views.

## 🧪 Testing Done
* Verified that authorized workflows executing through `apiRequest()` now dynamically attach the nested JWT token string.
* Inspected network headers to ensure they successfully transition away from `Bearer null` to the actual signed token payload.


---
@NileshBagade734-ux Please review and merge this under GSSoC '26 with the suitable labels! 🎉