### PR TITLE
Fix applicant linking in job applications

### DIFF
--- a/backend/controllers/studentController.js
+++ b/backend/controllers/studentController.js
@@ -92,9 +92,9 @@ export const applyJob = async (req, res) => {
       student: studentProfile._id,
       job: jobId
     });
+    job.applicants.push(application._id);
+    await job.save();
     console.log("🧰 application created:", application);
-
-    // ⚡ UPDATE JOB DOCUMENT: push application ID
    
 
     res.status(201).json({


### PR DESCRIPTION
## Fix
Linked newly created applications to the corresponding Job document by updating the applicants array after application creation.

## Why
Previously, applications were created successfully, but the Job model was not updated with the related application ID, causing inconsistency between Job and Application collections.

## Changes Made
- Added application ID push into job.applicants
- Saved updated Job document after application creation