### PR TITLE
Fix profile completion percentage sync between dashboard and profile

### DIFF
--- a/frontend/js/student-dashboard.js
+++ b/frontend/js/student-dashboard.js
@@ -18,6 +18,7 @@ document.addEventListener("DOMContentLoaded", () => {
 async function initDashboard() {
   showWelcome();
   await loadApplications();
+  await loadProfileCompletion();
   attachLogout();
 }
 
@@ -76,6 +77,34 @@ function renderDashboardTable(apps) {
   `).join("");
 
   lucide.createIcons();
+}
+
+async function loadProfileCompletion() {
+  try {
+    const res = await fetch(`${API_BASE}/student/profile`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    if (!res.ok) throw new Error("Failed to fetch profile");
+    const profile = await res.json();
+
+    const filled = [
+      profile.name,
+      profile.roll,
+      profile.branch,
+      profile.cgpa,
+      profile.skills && profile.skills.length > 0,
+      profile.resume
+    ].filter(Boolean).length;
+
+    const percent = Math.floor((filled / 6) * 100);
+
+    const label = document.getElementById("completion-label");
+    const bar = document.getElementById("progress-bar");
+    if (label) label.textContent = percent + "%";
+    if (bar) bar.style.width = percent + "%";
+  } catch (err) {
+    console.error("Profile completion error:", err);
+  }
 }
 
 function attachLogout() {


### PR DESCRIPTION
Closes #154

This PR fixes a profile completion synchronization issue where the Dashboard displayed a static `0%` value while the Profile page showed the correct completion percentage based on the student's profile data.

The Dashboard now fetches profile information from the same API endpoint used by the Profile page and applies the same completion calculation logic. As a result, both pages consistently display the same completion percentage and progress bar status.

I verified the fix locally by updating profile details and comparing the completion percentage across both pages. The Dashboard now correctly reflects profile updates and stays synchronized with the Profile page.

Below Screenshot demonstrating the issue before the fix and the corrected behavior after implementation have been attached.
<img width="1919" height="886" alt="Screenshot 2026-05-29 235115" src="https://github.com/user-attachments/assets/46791fb0-ffb7-4ef5-b61f-345ed0184b0e" />
