### PR TITLE
feature: Theme toggle is added to all pages

### DIFF
--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -188,6 +188,90 @@
     @media (max-width: 480px) {
       .footer-grid { grid-template-columns: 1fr; }
     }
+    /* Theme Toggle Button */
+.theme-toggle{
+  background: #f3f4f6;
+  border: none;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 18px;
+  color: #374151;
+  transition: all 0.3s ease;
+  margin-right: 12px;
+}
+
+.theme-toggle:hover{
+  transform: rotate(15deg);
+  background: #e5e7eb;
+}
+/* DARK MODE */
+
+body.dark-mode{
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+/* Header */
+body.dark-mode .header{
+  background: #1e293b;
+  border-bottom: 1px solid #334155;
+}
+
+body.dark-mode .nav-menu a,
+body.dark-mode .logo,
+body.dark-mode .menu-toggle{
+  color: #f8fafc;
+}
+
+/* Hero Features */
+body.dark-mode .feature,
+body.dark-mode .stats-card{
+  background: #1e293b;
+  color: #f8fafc;
+}
+
+body.dark-mode .feature p,
+body.dark-mode .hero p{
+  color: #cbd5e1;
+}
+
+/* Buttons */
+body.dark-mode .secondary{
+  background: #334155;
+  color: #fff;
+}
+
+/* Documentation Portal */
+body.dark-mode .portal-content{
+  background: #1e293b;
+}
+
+body.dark-mode .portal-body,
+body.dark-mode .portal-header h2,
+body.dark-mode .portal-body h2,
+body.dark-mode .portal-body h3{
+  color: #f8fafc;
+}
+
+body.dark-mode .portal-nav{
+  background: #0f172a;
+}
+
+body.dark-mode .portal-nav-btn{
+  color: #cbd5e1;
+}
+
+/* Mobile Menu */
+body.dark-mode .nav-menu{
+  background: #1e293b;
+}
+
+/* Footer */
+body.dark-mode footer{
+  background: #020617;
+}
   </style>
 </head>
 
@@ -196,7 +280,9 @@
 <header class="header">
   <div class="nav" style="position: relative;">
     <div class="text-xl font-bold"><i class="fa-solid fa-arrow-up-right-dots"></i>  PlacementorAI</div>
-    
+    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Theme">
+  <i class="fa-solid fa-moon"></i>
+</button>
     <button class="menu-toggle" id="mobile-menu-btn" aria-label="Toggle Navigation Menu">
       <i class="fa-solid fa-bars" id="menu-icon"></i>
     </button>
@@ -527,6 +613,30 @@ s1.setAttribute('crossorigin','*');
 s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
+<script>
+const themeToggle = document.getElementById("theme-toggle");
+const themeIcon = themeToggle.querySelector("i");
 
+/* Load saved theme */
+if(localStorage.getItem("theme") === "dark"){
+  document.body.classList.add("dark-mode");
+  themeIcon.classList.remove("fa-moon");
+  themeIcon.classList.add("fa-sun");
+}
+
+themeToggle.addEventListener("click", () => {
+  document.body.classList.toggle("dark-mode");
+
+  if(document.body.classList.contains("dark-mode")){
+    localStorage.setItem("theme", "dark");
+    themeIcon.classList.remove("fa-moon");
+    themeIcon.classList.add("fa-sun");
+  } else {
+    localStorage.setItem("theme", "light");
+    themeIcon.classList.remove("fa-sun");
+    themeIcon.classList.add("fa-moon");
+  }
+});
+</script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -153,6 +153,90 @@
     @media (max-width: 480px) {
       .footer-grid { grid-template-columns: 1fr; }
     }
+    /* Theme Toggle Button */
+.theme-toggle{
+  background: #f3f4f6;
+  border: none;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 18px;
+  color: #374151;
+  transition: all 0.3s ease;
+  margin-right: 12px;
+}
+
+.theme-toggle:hover{
+  transform: rotate(15deg);
+  background: #e5e7eb;
+}
+/* DARK MODE */
+
+body.dark-mode{
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+/* Header */
+body.dark-mode .header{
+  background: #1e293b;
+  border-bottom: 1px solid #334155;
+}
+
+body.dark-mode .nav-menu a,
+body.dark-mode .logo,
+body.dark-mode .menu-toggle{
+  color: #f8fafc;
+}
+
+/* Hero Features */
+body.dark-mode .feature,
+body.dark-mode .stats-card{
+  background: #1e293b;
+  color: #f8fafc;
+}
+
+body.dark-mode .feature p,
+body.dark-mode .hero p{
+  color: #cbd5e1;
+}
+
+/* Buttons */
+body.dark-mode .secondary{
+  background: #334155;
+  color: #fff;
+}
+
+/* Documentation Portal */
+body.dark-mode .portal-content{
+  background: #1e293b;
+}
+
+body.dark-mode .portal-body,
+body.dark-mode .portal-header h2,
+body.dark-mode .portal-body h2,
+body.dark-mode .portal-body h3{
+  color: #f8fafc;
+}
+
+body.dark-mode .portal-nav{
+  background: #0f172a;
+}
+
+body.dark-mode .portal-nav-btn{
+  color: #cbd5e1;
+}
+
+/* Mobile Menu */
+body.dark-mode .nav-menu{
+  background: #1e293b;
+}
+
+/* Footer */
+body.dark-mode footer{
+  background: #020617;
+}
   </style>
 </head>
 <body>
@@ -163,7 +247,9 @@
       <i class="fa-solid fa-arrow-up-right-dots"></i> 
       <span>PlacementorAI</span>
     </div>
-    
+    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Theme">
+  <i class="fa-solid fa-moon"></i>
+</button>
     <button class="menu-toggle" id="mobile-menu-btn" aria-label="Toggle Navigation Menu">
       <i class="fa-solid fa-bars" id="menu-icon"></i>
     </button>
@@ -374,6 +460,30 @@
 </script>
 <script src="https://cdn.botpress.cloud/webchat/v3.5/inject.js"></script>
 <script src="https://files.bpcontent.cloud/2026/01/29/16/20260129163015-0ZV4O3BK.js" defer></script>
+<script>
+const themeToggle = document.getElementById("theme-toggle");
+const themeIcon = themeToggle.querySelector("i");
 
+/* Load saved theme */
+if(localStorage.getItem("theme") === "dark"){
+  document.body.classList.add("dark-mode");
+  themeIcon.classList.remove("fa-moon");
+  themeIcon.classList.add("fa-sun");
+}
+
+themeToggle.addEventListener("click", () => {
+  document.body.classList.toggle("dark-mode");
+
+  if(document.body.classList.contains("dark-mode")){
+    localStorage.setItem("theme", "dark");
+    themeIcon.classList.remove("fa-moon");
+    themeIcon.classList.add("fa-sun");
+  } else {
+    localStorage.setItem("theme", "light");
+    themeIcon.classList.remove("fa-sun");
+    themeIcon.classList.add("fa-moon");
+  }
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
Hi,
closes #184 
Add a theme toggle button that allows users to switch between Light Mode and Dark Mode. The selected theme should be applied across the entire website and saved in the browser so that the user's preference persists across sessions.
Users have different visual preferences and accessibility needs. A dark mode option improves readability in low-light environments and enhances the overall user experience.
<img width="1899" height="964" alt="image" src="https://github.com/user-attachments/assets/a41c7efd-59ba-47ae-8e49-c265127245da" />
<img width="1916" height="970" alt="image" src="https://github.com/user-attachments/assets/32073235-db9e-457d-9795-ec9e2c8ca956" />
please merge this with proper labels.
thank you