### PR TITLE
fix: replace onclick div with anchor tags in recruiter sidebar

### DIFF
--- a/frontend/recruiter/recruiter-dashboard.html
+++ b/frontend/recruiter/recruiter-dashboard.html
@@ -13,15 +13,15 @@
         <aside class="w-64 bg-white border-r border-slate-200 p-6 hidden md:block">
             <h1 class="text-xl font-bold text-indigo-600 mb-10">PlacementorAI</h1>
             <nav class="space-y-2">
-                <div class="sidebar-item active">
+                <a href="recruiter-dashboard.html" class="sidebar-item active">
                     <i data-lucide="layout-dashboard"></i> <span>Dashboard</span>
-                </div>
-                <div class="sidebar-item" onclick="location.href='postjob.html'">
+                </a>
+                <a href="postjob.html" class="sidebar-item">
                     <i data-lucide="plus-circle"></i> <span>Post Job</span>
-                </div>
-                <div class="sidebar-item" onclick="location.href='manage-applicant.html'">
+                </a>
+                <a href="manage-applicant.html" class="sidebar-item">
                     <i data-lucide="users"></i> <span>Manage Applicants</span>
-                </div>
+                </a>
             </nav>
         </aside>
 
@@ -78,7 +78,7 @@
                 <div class="card">
                     <h3 class="section-title">Active Job Postings</h3>
                     <div id="jobs-container" class="space-y-4">
-                        </div>
+                    </div>
                 </div>
             </div>
         </main>
@@ -86,11 +86,11 @@
 
     <script src="../js/recruiter-dashboard.js"></script>
     <script src="https://cdn.botpress.cloud/webchat/v3.5/inject.js"></script>
-<script src="https://files.bpcontent.cloud/2026/01/29/16/20260129163015-0ZV4O3BK.js" defer></script>
+    <script src="https://files.bpcontent.cloud/2026/01/29/16/20260129163015-0ZV4O3BK.js" defer></script>
 
-<!-- Botpress Chatbot Scripts -->
- <script>
-  lucide.createIcons();
-</script>
+    <!-- Botpress Chatbot Scripts -->
+    <script>
+        lucide.createIcons();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Replaced `div+onclick` navigation with proper `<a href>` 
anchor tags in recruiter-dashboard.html sidebar to fix 
accessibility and consistency issues.

## Changes Made
- Replaced `<div class="sidebar-item" onclick="location.href='postjob.html'">` 
  with `<a href="postjob.html" class="sidebar-item">`
- Replaced `<div class="sidebar-item" onclick="location.href='manage-applicant.html'">` 
  with `<a href="manage-applicant.html" class="sidebar-item">`
- Added `<a href="recruiter-dashboard.html" class="sidebar-item active">` 
  for Dashboard link
- Styling kept consistent across all recruiter pages

## Why This Matters
- ✅ Keyboard navigation now works (Tab key)
- ✅ Right click "Open in new tab" supported
- ✅ Navigation works even if JS fails to load
- ✅ Consistent with postjob.html and manage-applicant.html
- ✅ Better accessibility standards followed

## Related Issue
Closes #235

## Type of Change
- [x] Bug fix
- [x] Accessibility fix