### PR TITLE
fix: correct sidebar link for student verification page

### DIFF
--- a/frontend/admin/admin-studentverify.html
+++ b/frontend/admin/admin-studentverify.html
@@ -15,7 +15,7 @@
       <a href="admin-dashboard.html" class="nav-item">
         <i class="fa-solid fa-grip"></i> Dashboard
       </a>
-      <a href="adminverify-student.html" class="nav-item active">
+      <a href="admin-studentverify.html" class="nav-item active">
         <i class="fa-solid fa-user-check"></i> Verify Students
       </a>
       <a href="admin-managejob.html" class="nav-item">


### PR DESCRIPTION
# Changes
- Fixed incorrect sidebar link for student verification page
- Updated route navigation

# Reason
The previous sidebar link redirected incorrectly / showed 404.

# Testing
- Verified sidebar navigation works correctly

Fixes #159 