### PR TITLE
Bug: the links are made interactive

### DIFF
--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -573,9 +573,17 @@ body.dark-mode .faq-answer p{
         <h3>PlacementorAI</h3>
         <p>Your intelligent companion for career growth and recruitment management. Streamlining the path from campus to corporate.</p>
         <div class="footer-social">
-          <a href="#"><i class="fa-brands fa-linkedin"></i></a>
-          <a href="#"><i class="fa-brands fa-github"></i></a>
-          <a href="#"><i class="fa-brands fa-x-twitter"></i></a>
+            <a href="https://www.linkedin.com" target="_blank" rel="noopener noreferrer">
+    <i class="fa-brands fa-linkedin"></i>
+  </a>
+
+  <a href="https://github.com" target="_blank" rel="noopener noreferrer">
+    <i class="fa-brands fa-github"></i>
+  </a>
+
+  <a href="https://x.com" target="_blank" rel="noopener noreferrer">
+    <i class="fa-brands fa-x-twitter"></i>
+  </a>
         </div>
       </div>
       <div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -325,11 +325,20 @@ body.dark-mode footer{
       <div>
         <h3>PlacementorAI</h3>
         <p>Your intelligent companion for career growth and recruitment management. Streamlining the path from campus to corporate.</p>
-        <div class="footer-social">
-          <a href="#"><i class="fa-brands fa-linkedin"></i></a>
-          <a href="#"><i class="fa-brands fa-github"></i></a>
-          <a href="#"><i class="fa-brands fa-x-twitter"></i></a>
-        </div>
+        
+          <div class="footer-social">
+  <a href="https://www.linkedin.com" target="_blank" rel="noopener noreferrer">
+    <i class="fa-brands fa-linkedin"></i>
+  </a>
+
+  <a href="https://github.com" target="_blank" rel="noopener noreferrer">
+    <i class="fa-brands fa-github"></i>
+  </a>
+
+  <a href="https://x.com" target="_blank" rel="noopener noreferrer">
+    <i class="fa-brands fa-x-twitter"></i>
+  </a>
+</div>
       </div>
       <div>
         <h4>Platform</h4>


### PR DESCRIPTION
Hi, @NileshBagade734-ux 
closes #228 

I am the contributor of GSSOC 2026

I have fixed the bug of the linkedin gitbub and twitter not being interactive.

The social media icons (LinkedIn, GitHub, and X/Twitter) in the footer were previously not redirecting to their respective external platforms. All links were using placeholder values (href="#"), which caused them to either stay on the same page or not navigate correctly.
Updated the anchor tags with correct external URLs for each platform and added target="_blank" along with rel="noopener noreferrer" to ensure safe opening in a new tab.


<img width="1870" height="963" alt="image" src="https://github.com/user-attachments/assets/d54a51d4-5835-4b09-b3e0-91cc2b45b044" />
