### PR TITLE
feat(security): prevent NoSQL injection using express-mongo-sanitize

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.6",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
+        "express-mongo-sanitize": "^2.2.0",
         "express-rate-limit": "^8.5.2",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.1.5"
@@ -452,6 +453,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-mongo-sanitize": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/express-mongo-sanitize/-/express-mongo-sanitize-2.2.0.tgz",
+      "integrity": "sha512-PZBs5nwhD6ek9ZuP+W2xmpvcrHwXZxD5GdieX2dsjPbAbH4azOkrHbycBud2QRU+YQF1CT+pki/lZGedHgo/dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/express-rate-limit": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
+    "express-mongo-sanitize": "^2.2.0",
     "express-rate-limit": "^8.5.2",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.1.5"

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ import express from "express";
 import mongoose from "mongoose";
 import dotenv from "dotenv";
 import cors from "cors";
+import mongoSanitize from "express-mongo-sanitize";
 
 // Routes
 import studentRoutes from "./routes/studentRoutes.js";
@@ -28,6 +29,9 @@ app.use(
 // ✅ Body parsers
 app.use(express.json({ limit: "20mb" }));
 app.use(express.urlencoded({ extended: true, limit: "20mb" }));
+
+// ✅ Data Sanitization against NoSQL Injection
+app.use(mongoSanitize());
 
 /* ============================
    ROUTES


### PR DESCRIPTION
Closes #267 


# Summary
This PR integrates `express-mongo-sanitize` to globally sanitize incoming request payloads, protecting the API from NoSQL Injection vulnerabilities.

# Changes Made
- Installed `express-mongo-sanitize` dependency.
- Imported and configured the middleware globally in `backend/server.js`.

# Testing
- Tested locally by sending POST requests with payload keys containing `$`.
- Verified that the malicious keys are stripped before reaching the route handlers.
- Verified that normal login and registration flows continue to work properly.

# Impact
This secures the authentication and data retrieval endpoints from query selector injections, ensuring the integrity of the database.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified (N/A)
- [x] Accessibility considered (N/A)
