### PR TITLE
fix: replace duplicate Job schema with proper RecruiterSchema in recr…

### DIFF
--- a/backend/models/recruiter.js
+++ b/backend/models/recruiter.js
@@ -1,19 +1,17 @@
-// Job.js
 import mongoose from "mongoose";
 
-const jobSchema = new mongoose.Schema({
-  title: { type: String, required: true },
-  company: { type: String, required: true },
-  location: String,
-  description: String,
-  skillsRequired: [String],
-  salary: String,
-  cgpa: { type: Number, default: 0 },
-  branch: [String],
-  recruiter: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
-  applicants: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],
-  createdAt: { type: Date, default: Date.now }
-});
+const recruiterSchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true
+    },
+    company: { type: String },
+    designation: { type: String },
+  },
+  { timestamps: true }
+);
 
-const Job = mongoose.models.Job || mongoose.model("Job", jobSchema);
-export default Job;
+const Recruiter = mongoose.models.Recruiter || mongoose.model("Recruiter", recruiterSchema);
+export default Recruiter;


### PR DESCRIPTION
Fixes #215

## Problem
`backend/models/recruiter.js` contained a duplicate `Job` schema instead of a `Recruiter` schema, causing Mongoose to throw `OverwriteModelError: Cannot overwrite model 'Job' once compiled`.

## Fix
Replaced the duplicate schema with a proper `RecruiterSchema` that references the base `User` model via MongoDB ObjectId.

## Changes
- `backend/models/recruiter.js` — replaced Job schema with RecruiterSchema