### PR TITLE
fix: add missing About Us link to navbar

### DIFF
--- a/frontend/contact.html
+++ b/frontend/contact.html
@@ -363,6 +363,7 @@ body.dark-mode .faq-answer p{
 
     <nav class="nav-menu" id="nav-links-target">
       <a href="index.html">Home</a>
+      <a href="About.html">About Us</a>
       <a href="contact.html">Contact</a>
       <a href="register.html">Sign Up</a>
       <a href="login.html" class="login">Login</a>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -258,6 +258,7 @@ body.dark-mode footer{
 
     <nav class="nav-menu" id="nav-links-target">
       <a href="index.html">Home</a>
+      <a href="About.html">About Us</a>
       <a href="contact.html">Contact</a>
       <a href="register.html">Sign Up</a>
       <a href="login.html" class="login">Login</a>


### PR DESCRIPTION
## Related Issue

Closes #309 

---

## Description

This PR adds the missing `About Us` navigation link to the navbar in pages where it was absent.

## Changes Made

* Added:

```html
<a href="About.html">About Us</a>
```

to the navbar in:

* `index.html`
* `contact.html`

### Impact

* Improves navigation consistency across pages
* Makes the About page easier to access
* Aligns navbar links with the existing footer navigation
