### PR TITLE
fix: remove redundant  header tag in register.html

### DIFF
--- a/frontend/register.html
+++ b/frontend/register.html
@@ -80,7 +80,6 @@ connect-src 'self' http://localhost:5000 https://unpkg.com;
 <body class="bg-slate-50 dark:bg-gray-900 min-h-screen flex flex-col transition-colors">
 
   <header class="bg-white dark:bg-gray-800 border-b border-slate-200 dark:border-gray-700">
-    <header class="bg-white dark:bg-gray-800 border-b border-slate-200 dark:border-gray-700">
       <div class="max-w-7xl mx-auto px-6 py-4 flex justify-between items-center">
 
         


### PR DESCRIPTION
### Problem
`frontend/register.html` had two nested `<header>` opening tags but only one closing `</header>` tag. This caused invalid HTML structure which affected accessibility landmarks and DOM consistency across browsers.

### Before 
<img width="1137" height="422" alt="image" src="https://github.com/user-attachments/assets/a5f8394c-83ad-4cb5-aab0-3c13962efe7a" />


### After 
<img width="1212" height="410" alt="image" src="https://github.com/user-attachments/assets/c6c61874-1fb5-4088-bd3c-68e1693ccfc9" />



Changes Made
Removed the redundant `<header>` tag in `frontend/register.html` — now exactly one `<header>` / `</header>` pair wraps the page header content.

### Tested
- Verified single `<header>` tag exists
- No layout regressions observed
- Accessibility landmark `role="banner"` is intact

### Requested Labels 

| Label | Reason |
|-------|--------|
| `gssoc:approved` | Valid GSSoC issue |
| `level:beginner` | Single tag removal, simple fix |
| `quality:clean` | Minimal and focused change, no extra modifications |
| `type:bug` | Invalid HTML structure was causing DOM inconsistency |

Closes #317