### PR TITLE
fix: resolve recruiter job deletion failure by using correct user ID …

### DIFF
--- a/backend/controllers/recruiterController.js
+++ b/backend/controllers/recruiterController.js
@@ -234,7 +234,7 @@ export const deleteJob = async (req, res) => {
   try {
     const job = await Job.findOne({
       _id: req.params.id,
-      recruiter: req.user._id,
+      recruiter: req.user.id,
     });
     if (!job) return res.status(404).json({ message: "Job not found" });
 


### PR DESCRIPTION
### 📝 Description of Changes
This PR resolves the bug where recruiters were unable to delete their posted jobs (which returned a 404/Server Error).

- **Root Cause:** The database query inside the `deleteJob` handler in `backend/controllers/recruiterController.js` was looking up the recruiter using `req.user._id`. However, the `verifyToken` middleware attaches the user session data to `req.user` with `id` instead of `_id`.
- **Solution:** Modified the database query inside the `deleteJob` handler to use `req.user.id`, aligning it with the middleware and enabling successful job deletion.

### 🐛 Issue Reference
Fixes the bug: *Recruiter Job Deletion Failure: Recruiter delete API query looks up the wrong user field ID, preventing them from deleting any posted jobs (404 / Server error).*

### 🛠️ Verification Done
- Verified syntax using compiler/syntax checks.
- Ran backend locally and verified that the database successfully connects and the server spins up on port `5000`.
- Verified that jobs are now correctly deleted from the database along with all associated applications.

### 📌 Checklist
- [x] Code is clean, well-indented, and free of syntax errors.
- [x] Verified that `.env` config file is excluded from Git tracking (via `.gitignore`).
- [x] Only the necessary fix was applied without any unrelated changes.
