### PR TITLE
fix: correct logout redirect path in admin-managejob.html

### DIFF
--- a/frontend/admin/admin-managejob.html
+++ b/frontend/admin/admin-managejob.html
@@ -28,7 +28,9 @@
     <header class="topbar">
       <div class="topbar-user">
         <span>Administrator</span>
-        <a href="login.html" class="logout-btn"><i class="fa-solid fa-right-from-bracket"></i> Logout</a>
+        <a href="../login.html" class="logout-btn">
+          <i class="fa-solid fa-right-from-bracket"></i> Logout
+        </a>
       </div>
     </header>
 
@@ -54,7 +56,7 @@
             </tr>
           </thead>
           <tbody id="adminJobTableBody">
-            </tbody>
+          </tbody>
         </table>
       </div>
     </main>
@@ -62,8 +64,7 @@
 
   <script src="../js/admin-managejob.js"></script>
   <script src="https://cdn.botpress.cloud/webchat/v3.5/inject.js"></script>
-<script src="https://files.bpcontent.cloud/2026/01/29/16/20260129163015-0ZV4O3BK.js" defer></script>
+  <script src="https://files.bpcontent.cloud/2026/01/29/16/20260129163015-0ZV4O3BK.js" defer></script>
 
-<!-- Botpress Chatbot Scripts -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
Fixed incorrect logout redirect path in 
admin-managejob.html that was causing 404 error.

## Changes Made
- Changed `href="login.html"` to `href="../login.html"` 
  in logout button

## Before & After
**Before:**
- ❌ Logout click → 404 Page Not Found

**After:**
- ✅ Logout redirects to login page correctly

## Related Issue
Closes #313

## Type of Change
- [x] Bug fix