### PR TITLE
fix: standardize logout to clear JWT token across all admin pages

### DIFF
--- a/frontend/admin/admin-managejob.html
+++ b/frontend/admin/admin-managejob.html
@@ -28,7 +28,9 @@
     <header class="topbar">
       <div class="topbar-user">
         <span>Administrator</span>
-        <a href="login.html" class="logout-btn"><i class="fa-solid fa-right-from-bracket"></i> Logout</a>
+        <button onclick="logout()" class="logout-btn">
+          <i class="fa-solid fa-right-from-bracket"></i> Logout
+        </button>
       </div>
     </header>
 
@@ -54,7 +56,7 @@
             </tr>
           </thead>
           <tbody id="adminJobTableBody">
-            </tbody>
+          </tbody>
         </table>
       </div>
     </main>
@@ -62,8 +64,14 @@
 
   <script src="../js/admin-managejob.js"></script>
   <script src="https://cdn.botpress.cloud/webchat/v3.5/inject.js"></script>
-<script src="https://files.bpcontent.cloud/2026/01/29/16/20260129163015-0ZV4O3BK.js" defer></script>
+  <script src="https://files.bpcontent.cloud/2026/01/29/16/20260129163015-0ZV4O3BK.js" defer></script>
 
-<!-- Botpress Chatbot Scripts -->
+  <script>
+    function logout() {
+      localStorage.removeItem('placementor_session');
+      window.location.href = '../login.html';
+    }
+  </script>
+
 </body>
 </html>

--- a/frontend/admin/admin-studentverify.html
+++ b/frontend/admin/admin-studentverify.html
@@ -15,7 +15,7 @@
       <a href="admin-dashboard.html" class="nav-item">
         <i class="fa-solid fa-grip"></i> Dashboard
       </a>
-      <a href="adminverify-student.html" class="nav-item active">
+      <a href="admin-studentverify.html" class="nav-item active">
         <i class="fa-solid fa-user-check"></i> Verify Students
       </a>
       <a href="admin-managejob.html" class="nav-item">
@@ -28,9 +28,9 @@
     <header class="topbar">
       <div class="topbar-user">
         <span>Admin</span>
-        <a href="login.html" class="logout-btn">
+        <button onclick="logout()" class="logout-btn">
           <i class="fa-solid fa-right-from-bracket"></i> Logout
-        </a>
+        </button>
       </div>
     </header>
 
@@ -52,7 +52,7 @@
             </tr>
           </thead>
           <tbody id="studentTable">
-            </tbody>
+          </tbody>
         </table>
       </div>
     </main>
@@ -60,8 +60,14 @@
 
   <script src="../js/admin-studentverify.js"></script>
   <script src="https://cdn.botpress.cloud/webchat/v3.5/inject.js"></script>
-<script src="https://files.bpcontent.cloud/2026/01/29/16/20260129163015-0ZV4O3BK.js" defer></script>
+  <script src="https://files.bpcontent.cloud/2026/01/29/16/20260129163015-0ZV4O3BK.js" defer></script>
 
-<!-- Botpress Chatbot Scripts -->
+  <script>
+    function logout() {
+      localStorage.removeItem('placementor_session');
+      window.location.href = '../login.html';
+    }
+  </script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
Standardized logout across all admin pages by replacing 
plain href logout with proper logout() function that 
clears JWT token from localStorage.

## Changes Made
### admin-managejob.html
- Replaced <a href="../login.html"> with 
  <button onclick="logout()">
- Added logout() function that clears 
  placementor_session from localStorage

### admin-studentverify.html
- Replaced <a href="../login.html"> with 
  <button onclick="logout()">
- Added logout() function that clears 
  placementor_session from localStorage

## Before & After
**Before:**
- ❌ Token remained in localStorage after logout
- ❌ Back button could access admin pages
- ❌ Inconsistent with admin-dashboard.html

**After:**
- ✅ Token cleared on logout
- ✅ Session properly terminated
- ✅ Consistent with admin-dashboard.html

## Related Issue
Closes #314

## Type of Change
- [x] Bug fix
- [x] Security fix