### PR TITLE
fix : prevent duplicate company entries during placment creation

### DIFF
--- a/backend/controllers/recruiterController.js
+++ b/backend/controllers/recruiterController.js
@@ -30,10 +30,21 @@ export const createJob = async (req, res) => {
     if (!title || !company || !description || !deadline) {
       return res.status(400).json({ message: "Missing required fields" });
     }
+    const normalizedCompany = company.trim().toLowerCase();
+
+const existingCompany = await Job.findOne({
+  company: { $regex: new RegExp(`^${normalizedCompany}$`, "i") }
+});
+
+if (existingCompany) {
+  return res.status(400).json({
+    message: "Company already exists"
+  });
+}
 
     const job = await Job.create({
       title,
-      company,
+      company: company.trim(),
       description,
       cgpa,
       branch: branch || branches || [],


### PR DESCRIPTION
Description
Fixes #369
Changes Made
Added backend validation to prevent duplicate company entries during placement creation
Added case-insensitive duplicate company checking
Added whitespace trimming before saving company names
Preserved existing recruiter job creation workflow
Validation Covered
Prevents duplicate company names
Prevents uppercase/lowercase duplicates
Prevents whitespace-based duplicate entries
Files Modified
backend/controllers/recruiterController.js
Testing
Verified duplicate validation logic manually
Confirmed clean implementation with no syntax errors
Checked git diff for scoped changes only :::