### PR TITLE
security: block admin registration from guest signup

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -7,6 +7,10 @@ export const register = async (req, res) => {
   try {
     const { name, email, password, role } = req.body;
 
+    if (role === "admin") {
+      return res.status(403).json({ message: "Admin role registration is restricted." });
+    }
+
     const exists = await User.findOne({ email });
     if (exists) {
       return res.status(400).json({ message: "User already exists" });


### PR DESCRIPTION
# Related Issue
Closes #402 

# Problem
Bypassing role control triggers privilege escalation.

# Solution
Filter out "admin" from the allowed user-facing signup roles.
