### PR TITLE
fix: resolve relative path redirection discrepancies for student session

### DIFF
--- a/frontend/js/student-dashboard.js
+++ b/frontend/js/student-dashboard.js
@@ -4,7 +4,7 @@ const APPLICATION_KEY = "student_applications";
 const session = JSON.parse(localStorage.getItem("placementor_session"));
 
 if (!session || !session.token || session.user.role !== "student") {
-  window.location.href = "../login.html";
+  window.location.href = "/login.html";
 }
 
 const token = session.token;
@@ -98,7 +98,7 @@ function renderDashboardTable(apps) {
 function attachLogout() {
   document.getElementById("logoutBtn")?.addEventListener("click", () => {
     localStorage.clear();
-    window.location.href = "../login.html";
+    window.location.href = "/login.html";
   });
 }
 // =====================================


### PR DESCRIPTION
# Related Issue
Closes #408 

# Problem
Relative paths cause redirect loops in subfolders.

# Solution
Use absolute paths for redirects.
