### PR TITLE
fix: configure static local development port in vite config

### DIFF
--- a/frontend-react/vite.config.js
+++ b/frontend-react/vite.config.js
@@ -5,4 +5,8 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(),tailwindcss()],
+  server: {
+    port: 3000,
+    host: true
+  }
 })


### PR DESCRIPTION
# Related Issue
Closes #414 

# Problem
Dynamic frontend ports cause local API CORS errors.

# Solution
Configure Vite to run on a static port.
