### PR TITLE
security: sanitize inputs against NoSQL injection vectors

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -40,6 +40,9 @@ export const register = async (req, res) => {
 export const login = async (req, res) => {
   try {
     const { email, password, role } = req.body;
+    if (typeof email !== "string" || typeof password !== "string" || typeof role !== "string") {
+      return res.status(400).json({ message: "Invalid input types." });
+    }
 
     const user = await User.findOne({ email, role });
     if (!user) {


### PR DESCRIPTION

```markdown
# Related Issue
Closes #436 

# Problem
The login API endpoint accepts nested objects directly from `req.body`, leaving it vulnerable to NoSQL Injection attacks.

# Root Cause
Inputs are forwarded directly to Mongoose queries (e.g., `User.findOne({ email, role })`) without checking if the types are strings.

# Solution
Added strict type validation checking in the login controller. If `email`, `password`, or `role` is not a primitive string, the request is immediately rejected with a `400 Bad Request` status.

# Changes Made
* Added string validation check inside `login` controller in `backend/controllers/authController.js`.

# Testing
* Local POST login verification using Postman.
* Confirmed that sending object-based keys returns `400 Bad Request` instead of executing a MongoDB search query.

# Impact
* Mitigates authorization bypass risks.
* Prevents data leaks via query operator manipulation.

# Risks
* None. Standard client submissions sending strings are unaffected.
