### PR TITLE
ux: optimize mobile responsiveness on student stats board

### DIFF
--- a/frontend/css/student-dashboard.css
+++ b/frontend/css/student-dashboard.css
@@ -267,3 +267,13 @@ body.dark-mode #themeToggle {
     background-color: #334155;
     color: white;
 }
+/* Mobile responsiveness overrides */
+@media (max-width: 768px) {
+  .stats-grid {
+    grid-template-columns: 1fr !important;
+  }
+  .nav-container {
+    flex-direction: column;
+    gap: 15px;
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #438 

# Problem
Rigid grid widths and flex layouts cause layout overflows on narrow mobile screens.

# Root Cause
The CSS stylesheet uses hardcoded template columns without media queries to wrap columns for mobile devices.

# Solution
Added CSS media queries targeting widths below `768px` to force components like the stats board and dashboard layout lists into vertical single-column layouts.

# Changes Made
* Appended responsive rules and overrides to `frontend/css/student-dashboard.css`.

# Testing
* Tested layout responsive flows locally using Google Chrome DevTools mobile view.
* Verified that dashboard grids wrap cleanly into a vertical list on sizes down to 320px width.

# Impact
* Fixes visual overlap bugs.
* Drastically improves student mobile user experience.

# Risks
* None. Desktop screens are unaffected.
