### PR TITLE
fix: resolve Express 5 wildcard route startup crash

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -49,10 +49,9 @@ import globalErrorHandler from "./middlewares/errorMiddleware.js";
 import AppError from "./utils/AppError.js";
 
 // Handle unhandled routes
-app.all('*', (req, res, next) => {
+app.use((req, res, next) => {
   next(new AppError(`Can't find ${req.originalUrl} on this server!`, 404));
 });
-
 // Register Global Error Handling Middleware
 app.use(globalErrorHandler);
 


### PR DESCRIPTION
## Summary

Fixes a backend startup crash caused by the wildcard route handler in `server.js` when using Express 5.

The existing implementation used:

```js
app.all('*', (req, res, next) => {
  next(new AppError(`Can't find ${req.originalUrl} on this server!`, 404));
});
```

With the current dependency version (`express@^5.2.1`), this causes a `PathError` during application startup, preventing the backend from running.

## Changes Made

* Replaced the Express 5-incompatible wildcard route handler with a middleware-based catch-all handler.
* Preserved existing behavior for handling undefined routes and forwarding them to the global error handler.

## Issue Reproduced

Steps followed:

1. Clone the repository.
2. Navigate to the backend directory.
3. Run:

   ```bash
   npm install
   npm run dev
   ```
4. Observe backend crash:

   ```text
   PathError [TypeError]: Missing parameter name at index 1: *
   ```

## Verification

After applying the fix:

* Backend no longer crashes during startup.
* Application successfully proceeds to the MongoDB initialization stage.
* The original `PathError` is no longer triggered.

## Screenshots
<img width="1920" height="1080" alt="Screenshot (249)" src="https://github.com/user-attachments/assets/7125fcaf-fabf-491d-b261-0b6740a47645" />


## Related Issue

Closes #384 
