### PR TITLE
fix(recruiter): require admin approval for recruiter job postings

### DIFF
--- a/backend/controllers/recruiterController.js
+++ b/backend/controllers/recruiterController.js
@@ -40,7 +40,7 @@ export const createJob = async (req, res) => {
       skillsRequired,
       deadline: new Date(deadline),
       recruiter: recruiterId,
-      status: "approved",
+      status: "pending",
     });
 
     res.status(201).json({ success: true, job });


### PR DESCRIPTION
### What does this PR do?
This PR modifies the job creation logic so that recruiter job postings are saved with a default status of `"pending"` rather than `"approved"`.
### Why is this needed?
Previously, new job posts were created with `status: "approved"`, which immediately published them to the student job board and completely bypassed the intended Admin verification/approval workflow.
### Related Code Locations
* Modified [recruiterController.js](file:///e:/PlaceMentor369/backend/controllers/recruiterController.js#L43) to set status to `"pending"`.
* Integrates with the existing [job.js](file:///e:/PlaceMentor369/backend/models/job.js#L59) model status schema and the Admin job approval endpoints.
### Verification Plan
* Logged in as a Recruiter and posted a job; verified it has a status of `"pending"` in the database.
* Logged in as an Admin and verified the job appears in the pending list for approval.
* Logged in as a Student and verified the job is only visible after the Admin approves it.