### PR TITLE
feat: implement drag-and-drop support for student resume upload

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,10 @@
       },
       "devDependencies": {
         "nodemon": "^3.1.11"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@google/genai": {
@@ -406,6 +410,21 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "25.9.0",
@@ -2829,6 +2848,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/validator": {
       "version": "13.15.35",

--- a/frontend/css/student-profile.css
+++ b/frontend/css/student-profile.css
@@ -160,6 +160,16 @@ select:focus {
     background-color: rgba(37, 99, 235, 0.03);
 }
 
+#resumeDropArea.is-drag-over {
+    border-color: var(--primary);
+    background-color: rgba(37, 99, 235, 0.08);
+    transform: translateY(-2px);
+}
+
+#resumeDropArea.is-drag-over i {
+    color: var(--primary);
+}
+
 /* Hide default file input but keep accessible */
 #resumeInput {
     cursor: pointer;

--- a/frontend/js/student-profile.js
+++ b/frontend/js/student-profile.js
@@ -66,6 +66,7 @@ const skillInput = document.getElementById("skillInput");
 const skillLevelSelect = document.getElementById("skillLevel");
 
 const resumeInput = document.getElementById("resumeInput");
+const resumeDropArea = document.getElementById("resumeDropArea");
 const resumeActions = document.getElementById("resumeActions");
 const resumeFileName = document.getElementById("resumeFileName");
 const viewPdfBtn = document.getElementById("viewPdfBtn");
@@ -155,17 +156,13 @@ function clearResumeError() {
 // ============================
 // RESUME LOGIC
 // ============================
-resumeInput?.addEventListener("change", (e) => {
-    clearResumeError();
-
-    const file = e.target.files[0];
-
-    if (!file) return;
+function validateResumeFile(file) {
+    if (!file) return false;
 
     if (file.type !== "application/pdf") {
         showResumeError("Only PDF resumes are allowed.");
         resumeInput.value = "";
-        return;
+        return false;
     }
 
     const MAX_SIZE = 2 * 1024 * 1024;
@@ -173,6 +170,16 @@ resumeInput?.addEventListener("change", (e) => {
     if (file.size > MAX_SIZE) {
         showResumeError("Resume size must be under 2MB.");
         resumeInput.value = "";
+        return false;
+    }
+
+    return true;
+}
+
+function readResumeFile(file) {
+    clearResumeError();
+
+    if (!validateResumeFile(file)) {
         return;
     }
 
@@ -185,6 +192,35 @@ resumeInput?.addEventListener("change", (e) => {
     };
 
     reader.readAsDataURL(file);
+}
+
+function setResumeDragActive(isActive) {
+    resumeDropArea?.classList.toggle("is-drag-over", isActive);
+}
+
+resumeInput?.addEventListener("change", (e) => {
+    readResumeFile(e.target.files[0]);
+});
+
+["dragenter", "dragover"].forEach((eventName) => {
+    resumeDropArea?.addEventListener(eventName, (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setResumeDragActive(true);
+    });
+});
+
+["dragleave", "drop"].forEach((eventName) => {
+    resumeDropArea?.addEventListener(eventName, (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setResumeDragActive(false);
+    });
+});
+
+resumeDropArea?.addEventListener("drop", (e) => {
+    const file = e.dataTransfer?.files?.[0];
+    readResumeFile(file);
 });
 
 function showResumeUI(name) {


### PR DESCRIPTION
## 📌 Description

Implemented drag-and-drop support for resume upload on the Student Profile page. Users can now upload resumes either by clicking the upload area or by dragging and dropping files. The existing upload flow has been preserved, and dropped files go through the same validation process as click uploads.

## 🔗 Related Issue

Closes #547 

## 🛠 Changes Made

### Updated `frontend/js/student-profile.js`

* Added `resumeDropArea` reference.
* Extracted resume validation logic into a reusable `validateResumeFile()` function.
* Extracted file reading and preview logic into `readResumeFile()`.
* Preserved the existing click-to-upload behavior.
* Added drag-and-drop event handlers for:

  * `dragenter`
  * `dragover`
  * `dragleave`
  * `drop`
* Ensured dropped files use the same validation rules as click uploads:

  * PDF files only
  * Maximum size of 2MB

### Updated `frontend/css/student-profile.css`

* Added `.is-drag-over` styling for the resume upload area.
* Added visual feedback when a file is dragged over the upload box.




