### PR TITLE
fix: scope company check per recruiter in createJob (#560)

### DIFF
--- a/backend/controllers/recruiterController.js
+++ b/backend/controllers/recruiterController.js
@@ -31,7 +31,7 @@ export const createJob = async (req, res) => {
       return res.status(400).json({ message: "Missing required fields" });
     }
 
-    const existingJob = await Job.findOne({ title, company, recruiter: recruiterId, createdAt: { $gte: new Date(Date.now() - 5 * 60000) } });
+    const existingJob = await Job.findOne({ title: title.trim(), company: company.trim(), recruiter: recruiterId, createdAt: { $gte: new Date(Date.now() - 5 * 60000) } });
     if (existingJob) return res.status(400).json({ message: "Duplicate job posting detected. Please wait 5 minutes before posting the same job again." });
 
     const job = await Job.create({

--- a/backend/controllers/recruiterController.js
+++ b/backend/controllers/recruiterController.js
@@ -12,8 +12,6 @@ export const createJob = async (req, res) => {
     console.log("REQ.BODY:", req.body);
 
     const recruiterId = req.user.id;
-    const existingJob = await Job.findOne({ title, company, recruiter: recruiterId, createdAt: { $gte: new Date(Date.now() - 5 * 60000) } });
-    if (existingJob) return res.status(400).json({ message: "Duplicate job posting detected. Please wait 5 minutes before posting the same job again." });
 
     if (!recruiterId)
       return res.status(400).json({ message: "Recruiter ID missing" });
@@ -32,17 +30,9 @@ export const createJob = async (req, res) => {
     if (!title || !company || !description || !deadline) {
       return res.status(400).json({ message: "Missing required fields" });
     }
-    const normalizedCompany = company.trim().toLowerCase();
 
-const existingCompany = await Job.findOne({
-  company: { $regex: new RegExp(`^${normalizedCompany}$`, "i") }
-});
-
-if (existingCompany) {
-  return res.status(400).json({
-    message: "Company already exists"
-  });
-}
+    const existingJob = await Job.findOne({ title, company, recruiter: recruiterId, createdAt: { $gte: new Date(Date.now() - 5 * 60000) } });
+    if (existingJob) return res.status(400).json({ message: "Duplicate job posting detected. Please wait 5 minutes before posting the same job again." });
 
     const job = await Job.create({
       title,
@@ -142,8 +132,6 @@ export const updateApplicantStatus = async (req, res) => {
 export const getRecruiterDashboardStats = async (req, res) => {
   try {
     const recruiterId = req.user.id;
-    const existingJob = await Job.findOne({ title, company, recruiter: recruiterId, createdAt: { $gte: new Date(Date.now() - 5 * 60000) } });
-    if (existingJob) return res.status(400).json({ message: "Duplicate job posting detected. Please wait 5 minutes before posting the same job again." });
 
     const jobs = await Job.find({ recruiter: recruiterId }).select("_id");
     const jobIds = jobs.map((j) => j._id);


### PR DESCRIPTION
## Summary
Fixes #560
Fixes #559

## Root Cause
The `createJob` function had a company uniqueness check that queried the entire Job collection with no recruiter filter. This permanently blocked any company name already used by anyone on the platform.

## Changes
- Removed the global `existingCompany` check in `createJob` that blocked all recruiters from posting jobs for an existing company name
- Removed a misplaced duplicate-job check in `getRecruiterDashboardStats` that used undefined `title` and `company` variables, which would crash the dashboard endpoint

## Testing
- Multiple recruiters can now post jobs for the same company name
- Single recruiter duplicate prevention (5-minute window) still works correctly