### PR TITLE
feat: centralize client-side auth guard and fetch response interception

### DIFF
--- a/frontend/admin/admin-dashboard.html
+++ b/frontend/admin/admin-dashboard.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../css/admin-dashboard.css">
+  <script src="../js/authGuard.js"></script>
 </head>
 <body>
 

--- a/frontend/admin/admin-managejob.html
+++ b/frontend/admin/admin-managejob.html
@@ -6,6 +6,7 @@
   <title>Job Management | PlacementorAI</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="../css/admin-managejob.css">
+  <script src="../js/authGuard.js"></script>
 </head>
 <body>
 

--- a/frontend/admin/admin-studentverify.html
+++ b/frontend/admin/admin-studentverify.html
@@ -6,6 +6,7 @@
   <title>Student Verification | PlacementorAI</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="../css/admin-studentverify.css">
+  <script src="../js/authGuard.js"></script>
 </head>
 <body>
 

--- a/frontend/js/authGuard.js
+++ b/frontend/js/authGuard.js
@@ -1,0 +1,57 @@
+(function () {
+  const sessionStr = localStorage.getItem("placementor_session");
+  let isAuthenticated = false;
+  let userRole = null;
+
+  if (sessionStr) {
+    try {
+      const session = JSON.parse(sessionStr);
+      if (session && session.token && session.user && session.user.role) {
+        isAuthenticated = true;
+        userRole = session.user.role;
+      }
+    } catch (e) {
+      console.error("Error parsing session in authGuard", e);
+    }
+  }
+
+  // Redirect helper to route back to login.html reliably
+  const redirectToLogin = () => {
+    localStorage.removeItem("placementor_session");
+    localStorage.removeItem("token");
+    
+    const path = window.location.pathname;
+    // Since all dashboard pages are nested exactly one folder deep (admin/, recruiter/, student/),
+    // relative paths are highly reliable for local files (file://) and different domains.
+    if (path.includes("/admin/") || path.includes("/recruiter/") || path.includes("/student/")) {
+      window.location.href = "../login.html";
+    } else {
+      if (path.includes("/frontend/")) {
+        window.location.href = "/frontend/login.html";
+      } else {
+        window.location.href = "/login.html";
+      }
+    }
+  };
+
+  if (!isAuthenticated) {
+    redirectToLogin();
+    return;
+  }
+
+  // Check if user is accessing a folder that matches their role
+  const path = window.location.pathname.toLowerCase();
+  let isAuthorized = true;
+
+  if (path.includes("/admin/") && userRole !== "admin") {
+    isAuthorized = false;
+  } else if (path.includes("/recruiter/") && userRole !== "recruiter") {
+    isAuthorized = false;
+  } else if (path.includes("/student/") && userRole !== "student") {
+    isAuthorized = false;
+  }
+
+  if (!isAuthorized) {
+    redirectToLogin();
+  }
+})();

--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -7,6 +7,49 @@
 const API_BASE_URL = "http://localhost:5000/api";
 
 /**
+ * Centralized fetch wrapper that handles authentication and interception.
+ * @param {string} url - Target URL
+ * @param {object} options - Fetch options
+ * @returns {Promise<Response>} The fetch Response object
+ */
+async function fetchWithAuth(url, options = {}) {
+  const session = localStorage.getItem("placementor_session");
+  const token = session ? JSON.parse(session).token : null;
+
+  options.headers = options.headers || {};
+  if (token) {
+    options.headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  if (options.body && !options.headers["Content-Type"]) {
+    options.headers["Content-Type"] = "application/json";
+  }
+
+  const response = await fetch(url, options);
+
+  if (response.status === 401 || response.status === 403) {
+    localStorage.removeItem("placementor_session");
+    localStorage.removeItem("token");
+    alert("Your session has expired or you are unauthorized. Please log in again.");
+    
+    const path = window.location.pathname;
+    if (path.includes("/admin/") || path.includes("/recruiter/") || path.includes("/student/")) {
+      window.location.href = "../login.html";
+    } else {
+      if (path.includes("/frontend/")) {
+        window.location.href = "/frontend/login.html";
+      } else {
+        window.location.href = "/login.html";
+      }
+    }
+    // Return a pending promise to prevent further execution in the client script
+    return new Promise(() => {});
+  }
+
+  return response;
+}
+
+/**
  * Make an authenticated API request.
  * @param {string} endpoint - API endpoint (e.g., "/auth/login")
  * @param {string} method - HTTP method (GET, POST, PUT, DELETE)
@@ -14,30 +57,15 @@ const API_BASE_URL = "http://localhost:5000/api";
  * @returns {Promise<object>} Parsed JSON response
  */
 async function apiRequest(endpoint, method = "GET", body = null) {
-  const session = localStorage.getItem("placementor_session");
-  const token = session ? JSON.parse(session).token : null;
-
   const options = {
     method,
-    headers: { "Content-Type": "application/json" },
   };
-
-  if (token) {
-    options.headers["Authorization"] = `Bearer ${token}`;
-  }
 
   if (body) {
     options.body = JSON.stringify(body);
   }
 
-  const response = await fetch(`${API_BASE_URL}${endpoint}`, options);
-
-  if (response.status === 401) {
-    localStorage.removeItem("placementor_session");
-    alert("Your session has expired. Please log in again.");
-    window.location.href = "/login.html";
-    return;
-  }
+  const response = await fetchWithAuth(`${API_BASE_URL}${endpoint}`, options);
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ message: "Request failed" }));

--- a/frontend/js/skill-gap.js
+++ b/frontend/js/skill-gap.js
@@ -245,12 +245,8 @@ async function handleApply(jobId) {
   if (window.lucide) lucide.createIcons();
 
   try {
-    const res = await fetch(`${API_BASE}/apply/${jobId}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`
-      }
+    const res = await fetchWithAuth(`${API_BASE}/apply/${jobId}`, {
+      method: "POST"
     });
     const data = await res.json();
     if (!res.ok) throw new Error(data.message || "Apply failed");
@@ -275,9 +271,7 @@ async function init() {
   }
 
   try {
-    const res = await fetch(`${API_BASE}/skill-gap/${jobId}`, {
-      headers: { Authorization: `Bearer ${token}` }
-    });
+    const res = await fetchWithAuth(`${API_BASE}/skill-gap/${jobId}`);
     const data = await res.json();
 
     if (!res.ok) throw new Error(data.message || "Failed to load analysis");

--- a/frontend/js/student-dashboard.js
+++ b/frontend/js/student-dashboard.js
@@ -22,9 +22,7 @@ async function initDashboard() {
 
 async function loadProfileCompletion() {
   try {
-    const res = await fetch(`${API_BASE_URL}/student/profile`, {
-      headers: { Authorization: `Bearer ${session.token}` }
-    });
+    const res = await fetchWithAuth(`${API_BASE_URL}/student/profile`);
     if (!res.ok) return;
     const profile = await res.json();
     if (!profile) return;

--- a/frontend/js/student-profile.js
+++ b/frontend/js/student-profile.js
@@ -279,12 +279,8 @@ resetProfileBtn?.addEventListener("click", async () => {
     resetProfileBtn.innerText = "Resetting...";
 
     try {
-        const res = await fetch(`${API_BASE}/profile`, {
+        const res = await fetchWithAuth(`${API_BASE}/profile`, {
             method: "PATCH",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`
-            },
             body: JSON.stringify({
                 name: "",
                 roll: "",

--- a/frontend/recruiter/manage-applicant.html
+++ b/frontend/recruiter/manage-applicant.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="../css/style.css">
 <link rel="stylesheet" href="../css/manage-applicant.css">
 
+  <script src="../js/authGuard.js"></script>
 </head>
 <body class="bg-slate-50">
   <div class="flex min-h-screen">

--- a/frontend/recruiter/postjob.html
+++ b/frontend/recruiter/postjob.html
@@ -7,6 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/lucide@latest"></script>
   <link rel="stylesheet" href="../css/postjob.css" />
+  <script src="../js/authGuard.js"></script>
 </head>
 
 <body class="bg-slate-50">

--- a/frontend/recruiter/recruiter-dashboard.html
+++ b/frontend/recruiter/recruiter-dashboard.html
@@ -7,6 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/lucide@latest"></script>
     <link rel="stylesheet" href="../css/recruiter-dashboard.css" />
+    <script src="../js/authGuard.js"></script>
 </head>
 <body>
     <div class="flex min-h-screen">

--- a/frontend/student/prep-dashboard.html
+++ b/frontend/student/prep-dashboard.html
@@ -30,6 +30,7 @@
         font-weight: 700;
       }
     </style>
+    <script src="../js/authGuard.js"></script>
   </head>
   <body class="bg-slate-50 min-h-screen text-slate-800">
     <header

--- a/frontend/student/skill-gap.html
+++ b/frontend/student/skill-gap.html
@@ -7,6 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/lucide@latest"></script>
   <link rel="stylesheet" href="../css/skill-gap.css" />
+  <script src="../js/authGuard.js"></script>
 </head>
 <body class="bg-slate-50 min-h-screen flex">
 
@@ -231,6 +232,7 @@
     </div><!-- /analysis-content -->
   </main>
 
+  <script src="../js/config.js"></script>
   <script src="../js/skill-gap.js"></script>
 </body>
 </html>

--- a/frontend/student/student-application.html
+++ b/frontend/student/student-application.html
@@ -7,6 +7,7 @@
 
   <link rel="stylesheet" href="../css/student-application.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+  <script src="../js/authGuard.js"></script>
 </head>
 <body>
 

--- a/frontend/student/student-dashboard.html
+++ b/frontend/student/student-dashboard.html
@@ -12,6 +12,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../css/student-dashboard.css" />
+    <script src="../js/authGuard.js"></script>
   </head>
   <body
     id="dashboardBody"

--- a/frontend/student/student-joblist.html
+++ b/frontend/student/student-joblist.html
@@ -7,6 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/lucide@latest"></script>
   <link rel="stylesheet" href="../css/student-joblist.css">
+  <script src="../js/authGuard.js"></script>
 </head>
 <body class="bg-slate-50 overflow-hidden">
 

--- a/frontend/student/student-profile.html
+++ b/frontend/student/student-profile.html
@@ -7,6 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="../css/student-profile.css">
+    <script src="../js/authGuard.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-900">
 

--- a/frontend/utils/api.js
+++ b/frontend/utils/api.js
@@ -1,20 +1,54 @@
 const API_BASE = "http://localhost:5000/api";
 
-export async function apiRequest(endpoint, method = "GET", body) {
+export async function fetchWithAuth(url, options = {}) {
   // 1. Safely parse the nested token from the main session object
   const session = JSON.parse(localStorage.getItem("placementor_session"));
   
   // 2. Fallback to standalone token string to prevent breaking any other views
   const token = session?.token || localStorage.getItem("token");
 
-  const res = await fetch(API_BASE + endpoint, {
+  options.headers = options.headers || {};
+  if (token) {
+    options.headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  if (options.body && !options.headers["Content-Type"]) {
+    options.headers["Content-Type"] = "application/json";
+  }
+
+  const response = await fetch(url, options);
+
+  if (response.status === 401 || response.status === 403) {
+    localStorage.removeItem("placementor_session");
+    localStorage.removeItem("token");
+    alert("Your session has expired or you are unauthorized. Please log in again.");
+    
+    const path = window.location.pathname;
+    if (path.includes("/admin/") || path.includes("/recruiter/") || path.includes("/student/")) {
+      window.location.href = "../login.html";
+    } else {
+      if (path.includes("/frontend/")) {
+        window.location.href = "/frontend/login.html";
+      } else {
+        window.location.href = "/login.html";
+      }
+    }
+    return new Promise(() => {});
+  }
+
+  return response;
+}
+
+export async function apiRequest(endpoint, method = "GET", body) {
+  const options = {
     method,
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${token}`
-    },
-    body: body ? JSON.stringify(body) : null
-  });
+  };
+
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+
+  const res = await fetchWithAuth(API_BASE + endpoint, options);
 
   return res.json();
 }


### PR DESCRIPTION
## Summary

**What problem does this PR solve?**
Handles JWT token expirations and unauthorized client-side states cleanly by introducing a centralized auth guard and a fetch response interceptor. Previously, if a user's JWT expired or if they navigated directly to a protected URL (under `admin/`, `recruiter/`, or `student/`) without a token, the API calls failed silently and left them on a broken, empty dashboard UI.

This PR ensures unauthorized users are blocked from loading protected dashboards and are redirected back to the login screen cleanly.

**What changed?**
- **Centralized Auth Guard (`frontend/js/authGuard.js`):** Added a parser-blocking script in the `<head>` of all 12 protected pages to verify session token existence and role authorizations before the DOM fully paints, preventing flash of unauthorized dashboard content.
- **Fetch Interceptor Wrapper:** Added a global `fetchWithAuth(url, options)` utility in `config.js` and `api.js` to auto-inject Bearer tokens and intercept `401 Unauthorized` and `403 Forbidden` statuses. If intercepted, it clears the invalid token and redirects the browser cleanly to `login.html`.
- **Refactored Client Pages:** Updated direct `fetch` calls to route through `fetchWithAuth` in `student-profile.js`, `student-dashboard.js`, and `skill-gap.js`.

## Validation
- [x] Verified code syntax is clean and error-free using `node -c`.
- [x] Tested page redirection behavior with deleted/invalid local storage session keys.
