### PR TITLE
fix: prevent registration as admin (privilege escalation) during public registration

### DIFF
--- a/backend/middlewares/validationMiddleware.js
+++ b/backend/middlewares/validationMiddleware.js
@@ -44,8 +44,8 @@ export const validateRegister = [
     .withMessage("Password must contain at least one letter"),
 
   body("role")
-    .isIn(["student", "recruiter", "admin"])
-    .withMessage("Role must be student, recruiter, or admin"),
+    .isIn(["student", "recruiter"])
+    .withMessage("Role must be student or recruiter"),
 
   handleValidationErrors,
 ];


### PR DESCRIPTION
Closes #609 

## Summary

This PR fixes a critical privilege escalation vulnerability in the public registration endpoint.

## Problem
The `/api/auth/register` endpoint allowed unauthenticated users to register accounts with the `admin` role by sending:

```json
{
  "role": "admin"
}
```

(Files modified - backend/middlewares/validationMiddleware.js)